### PR TITLE
block access to some views that are not relevant for public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11928,10 +11928,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "leaflet": "^1.3.4",
     "leaflet-control-geocoder": "^1.6.0",
     "leaflet.markercluster": "^1.4.1",
+    "lodash": "^4.17.11",
     "mapbox.js": "^3.1.1",
     "proj4leaflet": "^1.0.2",
     "promise-polyfill": "7.1.2",

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,5 @@
-import _ from 'lodash'
+import toNumber from 'lodash/toNumber'
+import includes from 'lodash/includes'
 import Vue from 'vue'
 import Router from 'vue-router'
 import About from './views/About'
@@ -40,9 +41,9 @@ const router = new Router({
       },
       beforeEnter: (to, from, next) => {
         // number or NaN
-        let id = _.toNumber(_.get(to, 'params.id'))
+        let id = toNumber(_.get(to, 'params.id'))
         // don't show non-public maps, not secret, just not that relevant for the public
-        if (_.includes(nonPublicViews, id)) {
+        if (includes(nonPublicViews, id)) {
           next('/')
         } else {
           next()

--- a/src/router.js
+++ b/src/router.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import Vue from 'vue'
 import Router from 'vue-router'
 import About from './views/About'
@@ -7,6 +8,10 @@ import Maps from './views/Maps'
 import Viewer from './views/Viewer.vue'
 
 Vue.use(Router)
+
+// These views contain information that is not interesting for the public.
+// It is public information but not relevant
+const nonPublicViews = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 const router = new Router({
   routes: [
@@ -32,6 +37,16 @@ const router = new Router({
       component: Viewer,
       meta: {
         title: 'LIWO – Landelijk Informatiesysteem Water en Overstromingen'
+      },
+      beforeEnter: (to, from, next) => {
+        // number or NaN
+        let id = _.toNumber(_.get(to, 'params.id'))
+        // don't show non-public maps, not secret, just not that relevant for the public
+        if (_.includes(nonPublicViews, id)) {
+          next('/')
+        } else {
+          next()
+        }
       }
     },
     {


### PR DESCRIPTION
Solves LIWO-129. 
Using lodash to avoid some browser incompatibilities (`.includes` not available in IE) and not having to write `indexOf > -1`. 