### PR TITLE
[LIWO-592] Page titles for map viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liwo-static",
-  "version": "2.10.0",
+  "version": "2.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24229,6 +24229,11 @@
           }
         }
       }
+    },
+    "vue-head": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vue-head/-/vue-head-2.2.0.tgz",
+      "integrity": "sha512-Oss1gakOSPQ4e/XZ0yM7yolnhSDvfDYZbM6CDD3xkCpAyPfTR+Bv3tabgtKE41gHr5GzC/NJh1EwQSu7o05XRw=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url-search-params": "^0.10.0",
     "url-search-params-polyfill": "^5.0.0",
     "vue": "^2.6.10",
+    "vue-head": "^2.2.0",
     "vue-router": "^3.0.6",
     "vue2-leaflet": "^1.2.3",
     "vuex": "^3.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="shortcut icon" href="/public/favicon.png">
-    <title>LIWO – Landelijk Informatiesysteem Water en Overstromingen</title>
+    <title>LIWO</title>
   </head>
   <body>
     <noscript>

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,10 +20,36 @@
 
 <script>
 import { mapGetters } from 'vuex'
-
 import AppHeader from '../src/components/AppHeader.vue'
 
 export default {
+  components: {
+    AppHeader
+  },
+  head: {
+    title () {
+      if (!this.title) {
+        return {
+          inner: '',
+          separator: ' '
+        }
+      }
+
+      return {
+        inner: this.title
+      }
+    }
+  },
+  watch: {
+    title: {
+      immediate: true,
+      handler () {
+        // emit this event to let vue-head know it should update the title element
+        // https://www.npmjs.com/package/vue-head#update-elements-with-asynchronous-data-or-after-page-loaded
+        this.$emit('updateHead')
+      }
+    }
+  },
   computed: {
     ...mapGetters([
       'layerSet'
@@ -34,11 +60,9 @@ export default {
           return this.layerSet.title
         }
       }
+
       return this.$route.meta.title
     }
-  },
-  components: {
-    AppHeader
   }
 }
 </script>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -92,5 +92,6 @@ export default {
     font-size: 2.2em;
     margin: .25rem 0;
     text-align: left;
+    min-height: 45px;
   }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import App from './App.vue'
 import leafletDirective from './lib/leaflet-directive'
 import router from './router'
 import store from './store'
+import VueHead from 'vue-head'
 
 import '@babel/polyfill'
 import 'whatwg-fetch'
@@ -11,6 +12,7 @@ import 'url-polyfill'
 
 Vue.config.productionTip = false
 Vue.directive('leaflet', leafletDirective)
+Vue.use(VueHead)
 
 new Vue({
   router,

--- a/src/router.js
+++ b/src/router.js
@@ -18,7 +18,7 @@ const router = new Router({
       name: 'home',
       component: Home,
       meta: {
-        title: 'LIWO – Landelijk Informatiesysteem Water en Overstromingen'
+        title: null
       }
     },
     {
@@ -26,7 +26,7 @@ const router = new Router({
       name: 'maps',
       component: Maps,
       meta: {
-        title: 'LIWO - Kaarten'
+        title: 'Kaarten'
       }
     },
     {
@@ -34,7 +34,7 @@ const router = new Router({
       name: 'viewer',
       component: Viewer,
       meta: {
-        title: 'LIWO – Landelijk Informatiesysteem Water en Overstromingen'
+        title: null
       },
       // pass id to component
       props: (route) => {
@@ -96,7 +96,7 @@ const router = new Router({
       name: 'about',
       component: About,
       meta: {
-        title: 'LIWO - Over LIWO'
+        title: 'Over LIWO'
       }
     },
     {
@@ -104,7 +104,7 @@ const router = new Router({
       name: 'contact',
       component: Contact,
       meta: {
-        title: 'LIWO - Contact'
+        title: 'Contact'
       }
     },
     {
@@ -112,16 +112,10 @@ const router = new Router({
       name: 'accessibility',
       component: Accessibility,
       meta: {
-        title: 'LIWO - Toegankelijkheid'
+        title: 'Toegankelijkheid'
       }
     }
   ]
-})
-
-// change title for blind people
-router.beforeEach((to, from, next) => {
-  document.title = to.meta.title
-  next()
 })
 
 export default router

--- a/src/router.js
+++ b/src/router.js
@@ -34,6 +34,7 @@ const router = new Router({
       name: 'viewer',
       component: Viewer,
       meta: {
+        // Title will be filled in once `LayerSet` is loaded.
         title: null
       },
       // pass id to component


### PR DESCRIPTION
- Implements [vue-head](https://www.npmjs.com/package/vue-head)
- Template for title: `[title] | LIWO`

Note:
Took some extra time because I tried setting the title from the `Viewer.vue` route component, but that conflicted with setting the title from `App.vue` and sometimes resulted in an empty title.