### PR TITLE
Fix: closing notifications

### DIFF
--- a/src/components/NotificationBar.vue
+++ b/src/components/NotificationBar.vue
@@ -10,7 +10,7 @@
            >
       <div class="container">
         <img class="notification-bar__icon" :src="`${publicPath}icons/baseline-${notification.type}-24px.svg`"  />
-        <p class="notification-bar__message">{{ notification.message }} </p>
+        <p class="notification-bar__message">{{ notification.message }}</p>
         <button class="pop-up__close icon-close-big panel-close"><span class="sr-only">Sluiten</span></button>
       </div>
     </aside>
@@ -68,12 +68,21 @@ export default {
   },
   data () {
     return {
-      publicPath: process.env.BASE_URL
+      publicPath: process.env.BASE_URL,
+      cleanNotifications: []
     }
   },
-  computed: {
-    cleanNotifications () {
-      return _.map(this.notifications, (notification) => {
+  watch: {
+    notifications () {
+      this.formatNotifications()
+    }
+  },
+  mounted () {
+    this.formatNotifications()
+  },
+  methods: {
+    formatNotifications () {
+      this.cleanNotifications = _.map(this.notifications, (notification) => {
         const result = { ...notification }
         // use default type
         if (!['error', 'warning', 'info', 'confirm'].includes(notification.type)) {

--- a/src/map.config.js
+++ b/src/map.config.js
@@ -93,9 +93,9 @@ async function getServices () {
   if (services) {
     return services
   }
-  const url = 'config/webconfig.json'
+  // const url = 'config/webconfig.json'
   // TODO: how shall we configure this? Discuss with Peter
-  // url = 'config/webconfig-rws.json'
+  const url = 'config/webconfig-rws.json'
 
   const resp = await fetch(url)
   const result = await resp.json()

--- a/src/map.config.js
+++ b/src/map.config.js
@@ -93,9 +93,9 @@ async function getServices () {
   if (services) {
     return services
   }
-  // const url = 'config/webconfig.json'
+  const url = 'config/webconfig.json'
   // TODO: how shall we configure this? Discuss with Peter
-  const url = 'config/webconfig-rws.json'
+  // url = 'config/webconfig-rws.json'
 
   const resp = await fetch(url)
   const result = await resp.json()


### PR DESCRIPTION
earlier this sprint I changed the state to a computed property. This isn't the right solution here because we cannot set state from a computed property, and that is exactly what happens when we want to close a notification (`notification.show = false`).