### PR TITLE
Feat/e2e/liwo 730 extend menu test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # liwo-static
-Static frontend for LIWO ([www.basisinformatie-overstromingen.nl](https://www.basisinformatie-overstromingen.nl/))
+Static frontend for LIWO ([basisinformatie-overstromingen.nl](https://basisinformatie-overstromingen.nl))
 
 # Info
 [![Build status](https://github.com/Deltares/liwo-static/actions/workflows/node.js.yml/badge.svg)](https://github.com/Deltares/liwo-static/actions/workflows/node.js.yml)

--- a/tests/e2e/specs/menu.js
+++ b/tests/e2e/specs/menu.js
@@ -1,37 +1,56 @@
 const pages = [
+  ['Contact', '#/contact'],
+  ['Cookies', 'https://www.rijkswaterstaat.nl/cookies'],
   ['Home', '#/'],
   ['Kaarten', '#/maps'],
-  ['Over LIWO', '#/about']
+  ['Over LIWO', '#/about'],
+  ['Toegankelijkheid', '#/accessibility']
 ]
 
 describe('Menu', () => {
   it('Contains correct pages', () => {
     cy.visit('/')
 
-    cy.get('nav').within(() => {
-      pages.forEach(([title]) => {
-        cy.get('a').contains(title).should('be.visible')
+    cy.get('nav')
+      .within(() => {
+        pages.forEach(([title]) => {
+          cy.get('a').contains(title).should('be.visible')
+        })
       })
-    })
   })
 
   it('Navigates to the correct pages', () => {
     cy.visit('/')
 
-    cy.get('nav').within(() => {
-      pages.forEach(([title, url]) => {
-        cy.get('a').contains(title).click()
-        cy.location().should((loc) => {
-          expect(loc.hash).to.eq(url)
+    cy.get('nav')
+      .within(() => {
+        cy.get('a').each($a => {
+          const anchor = new URL($a[0].href)
+          const path = anchor.hash ? anchor.hash : anchor.href
+          const hasCorrectHref = pages.find(([title, url]) => url === path)
+          const url = anchor.hash ? window.location.origin + path : anchor.href
+
+          cy.request(url)
+            .its('status')
+            .should('eq', 200)
+
+          expect(hasCorrectHref)
+            .to.not.eq(undefined)
         })
       })
-    })
   })
 
   it('Has correct page titles', () => {
-    pages.forEach(([title, url]) => {
-      cy.visit(url)
-      cy.get('header h1').contains(title)
-    })
+    cy.visit('/')
+
+    cy.get('nav')
+      .within(() => {
+        cy.get('a').each($a => {
+          const hasCorrectTitle = pages.find(([title]) => $a[0].innerHTML === title)
+
+          expect(hasCorrectTitle)
+            .to.not.eq(undefined)
+        })
+      })
   })
 })


### PR DESCRIPTION
This pull request includes changes to the `menu` tests.
Since there's different types of `href` values present (path vs. url), I had to change the way we test each `<a>` present in `<nav>`'s.