### PR TITLE
LIWO-875: retry requests for getFeature

### DIFF
--- a/src/lib/leaflet-utils/layer-factory.js
+++ b/src/lib/leaflet-utils/layer-factory.js
@@ -140,7 +140,9 @@ export function createClusterGeoJson (layer, onClick) {
   const unselectedGeoJson = {
     ...layer.geojson
   }
-  unselectedGeoJson.features = unselectedGeoJson.features?.filter(feature => !feature.properties.selected)
+  if (unselectedGeoJson.features) {
+    unselectedGeoJson.features = unselectedGeoJson.features.filter(feature => !feature.properties.selected)
+  }
 
   return L.geoJson(unselectedGeoJson, options)
 }

--- a/src/lib/leaflet-utils/layer-factory.js
+++ b/src/lib/leaflet-utils/layer-factory.js
@@ -140,7 +140,10 @@ export function createClusterGeoJson (layer, onClick) {
   const unselectedGeoJson = {
     ...layer.geojson
   }
-  unselectedGeoJson.features = unselectedGeoJson.features.filter(feature => !feature.properties.selected)
+  if (unselectedGeoJson.features) {
+    unselectedGeoJson.features = unselectedGeoJson.features.filter(feature => !feature.properties.selected)
+  }
+
   return L.geoJson(unselectedGeoJson, options)
 }
 

--- a/src/lib/leaflet-utils/layer-factory.js
+++ b/src/lib/leaflet-utils/layer-factory.js
@@ -140,7 +140,8 @@ export function createClusterGeoJson (layer, onClick) {
   const unselectedGeoJson = {
     ...layer.geojson
   }
-  unselectedGeoJson.features = unselectedGeoJson.features.filter(feature => !feature.properties.selected)
+
+  unselectedGeoJson.features = unselectedGeoJson.features?.filter(feature => !feature.properties.selected)
   return L.geoJson(unselectedGeoJson, options)
 }
 

--- a/src/lib/leaflet-utils/layer-factory.js
+++ b/src/lib/leaflet-utils/layer-factory.js
@@ -140,10 +140,7 @@ export function createClusterGeoJson (layer, onClick) {
   const unselectedGeoJson = {
     ...layer.geojson
   }
-  if (unselectedGeoJson.features) {
-    unselectedGeoJson.features = unselectedGeoJson.features.filter(feature => !feature.properties.selected)
-  }
-
+  unselectedGeoJson.features = unselectedGeoJson.features.filter(feature => !feature.properties.selected)
   return L.geoJson(unselectedGeoJson, options)
 }
 

--- a/src/lib/leaflet-utils/layer-factory.js
+++ b/src/lib/leaflet-utils/layer-factory.js
@@ -140,8 +140,8 @@ export function createClusterGeoJson (layer, onClick) {
   const unselectedGeoJson = {
     ...layer.geojson
   }
-
   unselectedGeoJson.features = unselectedGeoJson.features?.filter(feature => !feature.properties.selected)
+
   return L.geoJson(unselectedGeoJson, options)
 }
 

--- a/src/lib/load-geojson.js
+++ b/src/lib/load-geojson.js
@@ -25,6 +25,8 @@ const getFeatures = (url, jsonLayer, layerSetId, retries = 0) => {
   return new Promise((resolve, reject) => {
     fetch(url, { mode: 'cors' })
       .then(resp => {
+        // Workaround for a bug in the geoserver,
+        // it returns 200 but the response is an XML with an error message
         if (
           resp.headers.get('content-type') &&
           !resp.headers.get('content-type').includes('application/json')
@@ -45,7 +47,7 @@ const getFeatures = (url, jsonLayer, layerSetId, retries = 0) => {
       })
       .catch(error => {
         if (retries < MAX_RETRIES) {
-          console.warn(`Retry ${retries + 1} - Error: ${error}`)
+          console.warn(`Retry ${retries + 1} - ${error}`)
           setTimeout(
             () =>
               getFeatures(url, jsonLayer, layerSetId, retries + 1)
@@ -54,7 +56,7 @@ const getFeatures = (url, jsonLayer, layerSetId, retries = 0) => {
             RETRY_DELAY
           )
         } else {
-          console.error(`Max retries exceeded - Error: ${error}`)
+          console.error(`Max retries exceeded - ${error}`)
           // Show an error notification if the layer is not available
           const notification = {
             message: 'Please retry in 5 to 10 minutes.',

--- a/src/lib/load-geojson.js
+++ b/src/lib/load-geojson.js
@@ -10,7 +10,7 @@ const requestOptions = ({ namespace, layer }) => ({
   version: '1.0.0',
   request: 'getFeature',
   typeName: `${namespace}:${layer}`,
-  outputFormat: `${layer === 'gebiedsindeling_doorbraaklocaties_buitendijks' ? 'csv' : 'application/json'}`,
+  outputFormat: 'application/json',
   // get this info unprojected
   // formally geojson does not support CRS
   srsName: 'EPSG:4326',

--- a/src/lib/load-geojson.js
+++ b/src/lib/load-geojson.js
@@ -3,6 +3,10 @@ import store from '@/store'
 
 const MAX_RETRIES = 5
 const RETRY_DELAY = 1000 // Delay in milliseconds between retries
+const EMPTY_GEOJSON = {
+  type: 'FeatureCollection',
+  features: []
+}
 
 const requestOptions = ({ namespace, layer }) => ({
   isActive: true,
@@ -51,13 +55,16 @@ const getFeatures = (url, jsonLayer, layerSetId, retries = 0) => {
           )
         } else {
           console.error(`Max retries exceeded - Error: ${error}`)
+          // Show an error notification if the layer is not available
           const notification = {
             message: 'Please retry in 5 to 10 minutes.',
             type: 'error',
             show: true
           }
           store.commit('addNotificationById', { id: layerSetId, notification })
-          reject(error)
+          // By returning an empty geojson we prevent the map from crashing,
+          // instead it displays the other available layers
+          resolve(EMPTY_GEOJSON)
         }
       })
   })

--- a/src/lib/load-layersets.js
+++ b/src/lib/load-layersets.js
@@ -73,7 +73,7 @@ export async function loadLayerSetById (id, options) {
       const variants = await Promise.all(
         layer.variants.map(async (variant) => {
           if (_.includes(['json', 'cluster'], variant.map.type)) {
-            const geojson = await loadGeojson(variant.map)
+            const geojson = await loadGeojson(variant.map, layerSet.id)
             variant.map.geojson = geojson
           }
           return variant

--- a/src/store.js
+++ b/src/store.js
@@ -91,7 +91,7 @@ export default new Vuex.Store({
         commit('setSelectedVariantIndexByBreachBandId', { selectedIndex, breachBandId })
       }
     },
-    async loadLayerSetById (state, { id }) {
+    async loadLayerSetById ({ commit, state }, { id }) {
       // Skip if we already loaded this layerSet
       if (_.has(state.layerSetsById, id)) {
         return
@@ -111,15 +111,16 @@ export default new Vuex.Store({
 
       // The layers are in a deep  structure. Flatten it before  building the notifications
       const layers = flattenLayerSet(layerSet)
-      const notifications = [...(state.notificationsById?.[id] || []), ...buildLayerSetNotifications(layers)]
+
+      const currentNotifications = state.notificationsById[id] || []
+      const notifications = [...currentNotifications, ...buildLayerSetNotifications(layers)]
 
       // TODO: the function is called setLayerSet[s]
       // but it only loads  the layers of 1 layerSet, make this consistent
-
-      state.commit('setLayerSetById', { id, layerSet: layerSet })
+      commit('setLayerSetById', { id, layerSet: layerSet })
 
       // TODO: why not in the view...
-      state.commit('setNotificationsById', { id, notifications })
+      commit('setNotificationsById', { id, notifications })
     }
 
   },

--- a/src/store.js
+++ b/src/store.js
@@ -111,8 +111,7 @@ export default new Vuex.Store({
 
       // The layers are in a deep  structure. Flatten it before  building the notifications
       const layers = flattenLayerSet(layerSet)
-
-      const notifications = buildLayerSetNotifications(layers)
+      const notifications = [...(state.notificationsById?.[id] || []), ...buildLayerSetNotifications(layers)]
 
       // TODO: the function is called setLayerSet[s]
       // but it only loads  the layers of 1 layerSet, make this consistent


### PR DESCRIPTION
**Ticket:** [LIWO-875](https://issuetracker.deltares.nl/browse/LIWO-875)

**Changes:**
- Retry the `getFeatures` request if the response format is not json.
- Show a notification for each layer we fail to find the features for.
- Load no layers on the map if one of the layers fails.

**To test:**
I didn't manage to reproduce the original bug, I always got the expected json response. To test the retries an notification I changed [this line](https://github.com/lsarni/liwo-static/blob/master/src/lib/load-geojson.js#L9) to `outputFormat: 'csv',` for all layers to fail, or 
```
outputFormat: `${layer === 'gebiedsindeling_doorbraaklocaties_buitendijks' ? 'csv' : 'application/json'}`,
```
 for 1 layer to fail.

<img width="1265" alt="image" src="https://github.com/Deltares/liwo-static/assets/15196342/87f99fde-4b83-48e4-8fa8-70e8664a64d5">
